### PR TITLE
Gradient flow analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 data/skeletons/*
 .vscode/
+runs/*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/src/skelcast/data/dataset.py
+++ b/src/skelcast/data/dataset.py
@@ -132,8 +132,9 @@ class NTURGBDCollateFn:
         batch_y = []
         for sample, _ in batch:
             x, y = self.get_windows(sample)
-            batch_x.append(x)
-            batch_y.append(y)
+            chunk_size, context_len, n_bodies, n_joints, n_dims = x.shape
+            batch_x.append(x.view(chunk_size, context_len, n_bodies * n_joints * n_dims))
+            batch_y.append(y.view(chunk_size, context_len, n_bodies * n_joints * n_dims))
         # Pad the sequences to the maximum sequence length in the batch
         batch_x = torch.nn.utils.rnn.pad_sequence(batch_x, batch_first=True)
         batch_y = torch.nn.utils.rnn.pad_sequence(batch_y, batch_first=True)

--- a/src/skelcast/experiments/runner.py
+++ b/src/skelcast/experiments/runner.py
@@ -9,6 +9,7 @@ from skelcast.models import SkelcastModule
 from skelcast.data.dataset import NTURGBDCollateFn, NTURGBDSample
 from skelcast.callbacks.console import ConsoleCallback
 from skelcast.callbacks.checkpoint import CheckpointCallback
+from skelcast.logger.base import BaseLogger
 
 class Runner:
     def __init__(self,
@@ -22,13 +23,14 @@ class Runner:
                  n_epochs: int = 10,
                  device: str = 'cpu',
                  checkpoint_dir: str = None,
-                 checkpoint_frequency: int = 1) -> None:
+                 checkpoint_frequency: int = 1,
+                 logger: BaseLogger = None) -> None:
         self.train_set = train_set
         self.val_set = val_set
         self.train_batch_size = train_batch_size
         self.val_batch_size = val_batch_size
         self.block_size = block_size
-        self._collate_fn = NTURGBDCollateFn(block_size=self.block_size)
+        self._collate_fn = NTURGBDCollateFn(block_size=self.block_size, is_packed=True)
         self.train_loader = DataLoader(dataset=self.train_set, batch_size=self.train_batch_size, shuffle=True, collate_fn=self._collate_fn)
         self.val_loader = DataLoader(dataset=self.val_set, batch_size=self.val_batch_size, shuffle=False, collate_fn=self._collate_fn)
         self.model = model
@@ -59,6 +61,7 @@ class Runner:
         assert os.path.exists(self.checkpoint_dir), f'The designated checkpoint directory `{self.checkpoint_dir}` does not exist.'
         self.checkpoint_callback = CheckpointCallback(checkpoint_dir=self.checkpoint_dir,
                                                       frequency=self.checkpoint_frequency)
+        self.logger = logger
 
     def setup(self):
         self.model.to(self.device)
@@ -80,6 +83,7 @@ class Runner:
             epoch_loss = sum(self.training_loss_per_step[epoch * self._total_train_batches:(epoch + 1) * self._total_train_batches]) / self._total_train_batches
             self.console_callback.on_epoch_end(epoch=epoch,
                                                epoch_loss=epoch_loss, phase='train')
+            self.logger.add_scalar(tag='train/epoch_loss', scalar_value=epoch_loss, global_step=epoch)
             self.training_loss_history.append(epoch_loss)
             for val_batch_idx, val_batch in enumerate(self.val_loader):
                 self.validation_step(val_batch=val_batch)
@@ -90,6 +94,7 @@ class Runner:
             self.console_callback.on_epoch_end(epoch=epoch, epoch_loss=epoch_loss, phase='val')
             self.validation_loss_history.append(epoch_loss)
             self.checkpoint_callback.on_epoch_end(epoch=epoch, runner=self)
+            self.logger.add_scalar(tag='val/epoch_loss', scalar_value=epoch_loss, global_step=epoch)
 
         return {
             'training_loss_history': self.training_loss_history,
@@ -111,6 +116,9 @@ class Runner:
         self.optimizer.step()
         # Print the loss
         self.training_loss_per_step.append(loss.item())
+        # Log it to the logger
+        if self.logger is not None:
+            self.logger.add_scalar(tag='train/step_loss', scalar_value=loss.item(), global_step=len(self.training_loss_per_step))
 
     def validation_step(self, val_batch: NTURGBDSample):
         x, y = val_batch.x, val_batch.y
@@ -121,6 +129,9 @@ class Runner:
         out = self.model.validation_step(x, y)
         loss = out['loss']
         self.validation_loss_per_step.append(loss.item())
+        # Log it to the logger
+        if self.logger is not None:
+            self.logger.add_scalar(tag='val/step_loss', scalar_value=loss.item(), global_step=len(self.validation_loss_per_step))
     
     def resume(self, checkpoint_path):
         """

--- a/src/skelcast/logger/base.py
+++ b/src/skelcast/logger/base.py
@@ -1,0 +1,23 @@
+
+from abc import ABC, abstractmethod
+
+class BaseLogger(ABC):
+    @abstractmethod
+    def add_scalar(self):
+        pass
+
+    @abstractmethod
+    def add_scalars(self):
+        pass
+    
+    @abstractmethod
+    def add_histogram(self):
+        pass
+
+    @abstractmethod
+    def add_image(self):
+        pass
+
+    @abstractmethod
+    def close(self):
+        pass

--- a/src/skelcast/logger/tensorboard_logger.py
+++ b/src/skelcast/logger/tensorboard_logger.py
@@ -1,0 +1,25 @@
+from torch.utils.tensorboard import SummaryWriter
+from skelcast.logger.base import BaseLogger
+
+
+class TensorboardLogger(BaseLogger):
+    def __init__(self, log_dir):
+        super().__init__()
+        self.writer = SummaryWriter(log_dir)
+
+    def add_scalar(self, tag, scalar_value, global_step=None, walltime=None):
+        self.writer.add_scalar(tag, scalar_value, global_step, walltime)
+
+    def add_scalars(self, main_tag, tag_scalar_dict, global_step=None, walltime=None):
+        self.writer.add_scalars(main_tag, tag_scalar_dict, global_step, walltime)
+
+    def add_histogram(self, tag, values, global_step=None, bins='tensorflow', walltime=None, max_bins=None):
+        self.writer.add_histogram(tag, values, global_step, bins, walltime, max_bins)
+
+    def add_image(self, tag, img_tensor, global_step=None, walltime=None, dataformats='CHW'):
+        self.writer.add_image(tag, img_tensor, global_step, walltime, dataformats)
+
+    # Implement other methods from SummaryWriter as needed
+
+    def close(self):
+        self.writer.close()

--- a/src/skelcast/models/module.py
+++ b/src/skelcast/models/module.py
@@ -6,6 +6,7 @@ class SkelcastModule(nn.Module, metaclass=abc.ABCMeta):
     def __init__(self) -> None:
         super(SkelcastModule, self).__init__()
         self.gradients = dict()
+        self.gradient_update_ratios = dict()
 
     @abc.abstractmethod
     def predict(self, *args, **kwargs):
@@ -28,10 +29,30 @@ class SkelcastModule(nn.Module, metaclass=abc.ABCMeta):
         """
         pass
 
-    def gradient_flow(self, *args, **kwargs):
+    def gradient_flow(self):
         """
         Implements the gradient flow step of a module
         """
         for name, param in self.named_parameters():
             if param.requires_grad and param.grad is not None:
-                self.gradients[name] = param.grad.clone()
+                self.gradients[name] = param.grad.clone().detach().cpu().numpy()
+
+    def compute_gradient_update_norm(self, lr: float):
+        """
+        Computes the ratio of the parameter update to the parameter norm and stores it to the gradient_update_ratios
+        dictionary. The gradient update is approximated as the vanilla gradient descent update.
+
+        Args:
+        -    lr (float): The optimizer's learning rate
+        """
+        for name, param in self.named_parameters():
+            if param.requires_grad and param.grad is not None:
+                self.gradient_update_ratios[name] = (lr * param.grad.norm() / param.norm()).detach().cpu().numpy()
+
+    def get_gradient_histograms(self):
+        """
+        Returns the flat gradients of the module's parameters from the gradients dictionary.
+        """
+        return {name: param.grad.clone().view(-1).detach().cpu().numpy() for name, param in self.named_parameters() if
+                param.requires_grad and param.grad is not None}
+    

--- a/src/skelcast/models/module.py
+++ b/src/skelcast/models/module.py
@@ -5,6 +5,7 @@ import torch.nn as nn
 class SkelcastModule(nn.Module, metaclass=abc.ABCMeta):
     def __init__(self) -> None:
         super(SkelcastModule, self).__init__()
+        self.gradients = dict()
 
     @abc.abstractmethod
     def predict(self, *args, **kwargs):
@@ -26,3 +27,11 @@ class SkelcastModule(nn.Module, metaclass=abc.ABCMeta):
         Implements a validation step of a module
         """
         pass
+
+    def gradient_flow(self, *args, **kwargs):
+        """
+        Implements the gradient flow step of a module
+        """
+        for name, param in self.named_parameters():
+            if param.requires_grad and param.grad is not None:
+                self.gradients[name] = param.grad.clone()


### PR DESCRIPTION
This PR adds a new feature to the `SkelcastModule` model wrapper. Concretely, it implements class methods to store the gradient information w.r.t parameters of the network. The vanilla gradient descent update norm to parameter norm ratio is also computed to check the stability of the model's training. Everything is stored to `SkelcastModule`'s `gradients` and `gradient_update_ratios` dictionaries.

An example computation of these measures would be:

```python
# Assume that model is an instance of the SkelcastModule class

def train(model, data_loader, optimizer, num_epochs):
    for epoch in range(num_epochs):
        for batch_idx, (x_batch, y_batch) in enumerate(data_loader):
            optimizer.zero_grad()
            
            # Forward pass
            outputs = model.training_step(x_batch, y_batch)
            loss = outputs['loss']

            # Backward pass
            loss.backward()

            model.gradient_flow()
            model.compute_gradient_update_norm()
            optimizer.step()
```