### PR TITLE
Human 3.6m Dataset

### DIFF
--- a/src/skelcast/data/dataset.py
+++ b/src/skelcast/data/dataset.py
@@ -309,6 +309,7 @@ class Human36mDataset(Dataset):
         self.train = train
 
         self.train_inputs, self.test_inputs = [], []
+        self.act = []
 
         if self.use_hourglass_detections:
             train_2d_file = 'train_2d_ft.pth.tar'
@@ -327,6 +328,7 @@ class Human36mDataset(Dataset):
                 k3d = (sub, act, fname[:-3]) if fname.endswith('-sh') else k3d
                 assert self.train_3d[k3d].shape[0] == self.train_2d[k2d].shape[0], f'(training) 3d and 2d shapes not matching'
                 self.train_inputs.append(self.train_3d[k3d])
+                self.act.append(act)
 
         else:
             self.test_3d = torch.load(os.path.join(data_path, 'test_3d.pth.tar'))
@@ -337,6 +339,7 @@ class Human36mDataset(Dataset):
                 k3d = (sub, act, fname[:-3]) if fname.endswith('-sh') else k3d
                 assert self.test_2d[k2d].shape[0] == self.test_3d[k3d].shape[0], '(test) 3d and 2d shapes not matching'
                 self.test_inputs.append(self.test_3d[k3d])
+                self.act.append(act)
     
     def __getitem__(self, index) -> Any:
         if self.train:
@@ -345,7 +348,7 @@ class Human36mDataset(Dataset):
             x = torch.from_numpy(self.train_inputs[index]).float()
         else:
             x = torch.from_numpy(self.test_inputs[index]).float()
-        return x.view(-1, 16, 3)
+        return x.view(-1, 16, 3), self.act[index]
 
     def __len__(self):
         if self.train:

--- a/src/skelcast/data/dataset.py
+++ b/src/skelcast/data/dataset.py
@@ -310,7 +310,6 @@ class Human36mDataset(Dataset):
         self.train = train
 
         self.train_inputs, self.test_inputs = [], []
-        # self.train_meta, self.test_meta = [], []
 
         if self.use_hourglass_detections:
             train_2d_file = 'train_2d_ft.pth.tar'
@@ -327,11 +326,7 @@ class Human36mDataset(Dataset):
                 (sub, act, fname) = k2d
                 k3d = k2d
                 k3d = (sub, act, fname[:-3]) if fname.endswith('-sh') else k3d
-                # num_f, _ = self.train_2d[k2d].shape
                 assert self.train_3d[k3d].shape[0] == self.train_2d[k2d].shape[0], f'(training) 3d and 2d shapes not matching'
-                # for i in range(num_f):
-                #     self.train_inputs.append(self.train_2d[k2d][i])
-                #     self.train_out.append(self.train_3d[k3d][i])
                 self.train_inputs.append(self.train_3d[k3d])
 
         else:
@@ -339,27 +334,18 @@ class Human36mDataset(Dataset):
             self.test_2d = torch.load(os.path.join(data_path, test_2d_file))
             for k2d in self.test_2d.keys():
                 (sub, act, fname) = k2d
-                # if act not in self.actions:
-                #     continue
                 k3d = k2d
                 k3d = (sub, act, fname[:-3]) if fname.endswith('-sh') else k3d
-                # num_f, _ = self.test_2d[k2d].shape
                 assert self.test_2d[k2d].shape[0] == self.test_3d[k3d].shape[0], '(test) 3d and 2d shapes not matching'
                 self.test_inputs.append(self.test_3d[k3d])
-                # for i in range(num_f):
-                #     self.test_inputs.append(self.test_2d[k2d][i])
-                #     self.test_out.append(self.test_3d[k3d][i])
     
     def __getitem__(self, index) -> Any:
         if self.train:
             # We want the sampeles to be returned as sequences
             # i.e.: [seq_len, n_joints, 3]
             x = torch.from_numpy(self.train_inputs[index]).float()
-
         else:
             x = torch.from_numpy(self.test_inputs[index]).float()
-            # y = torch.from_numpy(self.test_out[index]).float()
-
         return x.view(-1, 16, 3)
 
     def __len__(self):

--- a/src/skelcast/data/dataset.py
+++ b/src/skelcast/data/dataset.py
@@ -303,8 +303,7 @@ class NTURGBDDataset(Dataset):
 
 @DATASETS.register_module()
 class Human36mDataset(Dataset):
-    def __init__(self, actions, data_path, use_hourglass_detections=True, train=True) -> None:
-        self.actions = actions
+    def __init__(self, data_path, use_hourglass_detections=True, train=True) -> None:
         self.data_path = data_path
         self.use_hourglass_detections = use_hourglass_detections
         self.train = train

--- a/src/skelcast/data/dataset.py
+++ b/src/skelcast/data/dataset.py
@@ -309,8 +309,8 @@ class Human36mDataset(Dataset):
         self.use_hourglass_detections = use_hourglass_detections
         self.train = train
 
-        self.train_inputs, self.train_out, self.test_inputs, self.test_out = [], [], [], []
-        self.train_meta, self.test_meta = [], []
+        self.train_inputs, self.test_inputs = [], []
+        # self.train_meta, self.test_meta = [], []
 
         if self.use_hourglass_detections:
             train_2d_file = 'train_2d_ft.pth.tar'
@@ -327,11 +327,13 @@ class Human36mDataset(Dataset):
                 (sub, act, fname) = k2d
                 k3d = k2d
                 k3d = (sub, act, fname[:-3]) if fname.endswith('-sh') else k3d
-                num_f, _ = self.train_2d[k2d].shape
+                # num_f, _ = self.train_2d[k2d].shape
                 assert self.train_3d[k3d].shape[0] == self.train_2d[k2d].shape[0], f'(training) 3d and 2d shapes not matching'
-                for i in range(num_f):
-                    self.train_inputs.append(self.train_2d[k2d][i])
-                    self.train_out.append(self.train_3d[k3d][i])
+                # for i in range(num_f):
+                #     self.train_inputs.append(self.train_2d[k2d][i])
+                #     self.train_out.append(self.train_3d[k3d][i])
+                self.train_inputs.append(self.train_3d[k3d])
+
         else:
             self.test_3d = torch.load(os.path.join(data_path, 'test_3d.pth.tar'))
             self.test_2d = torch.load(os.path.join(data_path, test_2d_file))
@@ -341,22 +343,24 @@ class Human36mDataset(Dataset):
                 #     continue
                 k3d = k2d
                 k3d = (sub, act, fname[:-3]) if fname.endswith('-sh') else k3d
-                num_f, _ = self.test_2d[k2d].shape
+                # num_f, _ = self.test_2d[k2d].shape
                 assert self.test_2d[k2d].shape[0] == self.test_3d[k3d].shape[0], '(test) 3d and 2d shapes not matching'
-                for i in range(num_f):
-                    self.test_inputs.append(self.test_2d[k2d][i])
-                    self.test_out.append(self.test_3d[k3d][i])
+                self.test_inputs.append(self.test_3d[k3d])
+                # for i in range(num_f):
+                #     self.test_inputs.append(self.test_2d[k2d][i])
+                #     self.test_out.append(self.test_3d[k3d][i])
     
     def __getitem__(self, index) -> Any:
         if self.train:
+            # We want the sampeles to be returned as sequences
+            # i.e.: [seq_len, n_joints, 3]
             x = torch.from_numpy(self.train_inputs[index]).float()
-            y = torch.from_numpy(self.train_out[index]).float()
 
         else:
             x = torch.from_numpy(self.test_inputs[index]).float()
-            y = torch.from_numpy(self.test_out[index]).float()
+            # y = torch.from_numpy(self.test_out[index]).float()
 
-        return x, y
+        return x.view(-1, 16, 3)
 
     def __len__(self):
         if self.train:


### PR DESCRIPTION
Added the dataset wrapper for the Human3.6m. Original implementations have it return a $32 \times 1$ pose for the 2d case and a $48 \times 1$ pose for the 3d case. Therefore, every implementation returned only one pose, making the entire dataset having around 2 million poses, which makes sense.

However, in our case we want a sequence of poses so we omit the last part where the sequence is "flattened", meaning every time step of the sequence counts as an individual sample. We only maintain the 3d skeleton (we only care about 3d skeleton forecasting) and we end up with 600 variable sequence length skeleton motions.

See `src/skelcast/data/dataset.py` for the addition.

Seems like that it can work with the `NTURGBDCollateFnWithRandomSampledContextWindow` right away without modifications... not tested yet.